### PR TITLE
Removing access check for file creation

### DIFF
--- a/src/Plugin/GraphQL/Mutations/FileUpload.php
+++ b/src/Plugin/GraphQL/Mutations/FileUpload.php
@@ -157,13 +157,6 @@ class FileUpload extends MutationPluginBase implements ContainerFactoryPluginInt
     /** @var \Drupal\file\FileInterface $entity */
     $entity = $storage->create($values);
 
-    // Check if the current user is allowed to create file entities.
-    if (!$entity->access('create')) {
-      return new EntityCrudOutputWrapper(NULL, NULL, [
-        $this->t('You do not have the necessary permissions to create entities of this type.'),
-      ]);
-    }
-
     // Validate the entity values.
     if (($violations = $entity->validate()) && $violations->count()) {
       return new EntityCrudOutputWrapper(NULL, $violations);


### PR DESCRIPTION
I'm unable to create a file entity with the access check as written. 

Per the following file, it makes me think that it may not be possible to check whether or not you can create a file entity. 
File

`core/modules/file/src/FileAccessControlHandler.php, line 120`

```

protected function checkCreateAccess(AccountInterface $account, array $context, $entity_bundle = NULL) {
    // The file entity has no "create" permission because by default Drupal core
    // does not allow creating file entities independently. It allows you to
    // create file entities that are referenced from another entity
    // (e.g. an image for a article). A contributed module is free to alter
    // this to allow file entities to be created directly.
    // @todo Update comment to mention REST module when
    //   https://www.drupal.org/node/1927648 is fixed.
    return AccessResult::neutral();
  }
```

https://api.drupal.org/api/drupal/core%21modules%21file%21src%21FileAccessControlHandler.php/function/FileAccessControlHandler%3A%3AcheckCreateAccess/8.4.x