### PR TITLE
The current examples are out of date

### DIFF
--- a/src/Plugin/GraphQL/Mutations/CreateArticle.php
+++ b/src/Plugin/GraphQL/Mutations/CreateArticle.php
@@ -2,9 +2,10 @@
 
 namespace Drupal\graphql_examples\Plugin\GraphQL\Mutations;
 
-use Drupal\graphql\GraphQL\Type\InputObjectType;
+use Drupal\graphql\Annotation\GraphQLMutation;
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
 use Drupal\graphql_core\Plugin\GraphQL\Mutations\Entity\CreateEntityBase;
-use Youshido\GraphQL\Execution\ResolveInfo;
+use GraphQL\Type\Definition\ResolveInfo;
 
 /**
  * Simple mutation for creating a new article node.
@@ -26,7 +27,12 @@ class CreateArticle extends CreateEntityBase {
   /**
    * {@inheritdoc}
    */
-  protected function extractEntityInput(array $args, ResolveInfo $info) {
+  protected function extractEntityInput(
+    $value,
+    array $args,
+    ResolveContext $context,
+    ResolveInfo $info
+  ) {
     return [
       'title' => $args['input']['title'],
       'body' => $args['input']['body'],

--- a/src/Plugin/GraphQL/Mutations/FileUpload.php
+++ b/src/Plugin/GraphQL/Mutations/FileUpload.php
@@ -12,7 +12,7 @@ use Drupal\graphql\Plugin\GraphQL\Mutations\MutationPluginBase;
 use Drupal\graphql_core\GraphQL\EntityCrudOutputWrapper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface;
-use Youshido\GraphQL\Execution\ResolveInfo;
+use GraphQL\Type\Definition\ResolveInfo;
 
 /**
  * TODO: Add the whole range of file upload validations from file_save_upload().

--- a/src/Plugin/GraphQL/Mutations/UpdateArticle.php
+++ b/src/Plugin/GraphQL/Mutations/UpdateArticle.php
@@ -4,7 +4,7 @@ namespace Drupal\graphql_examples\Plugin\GraphQL\Mutations;
 
 use Drupal\graphql\GraphQL\Type\InputObjectType;
 use Drupal\graphql_core\Plugin\GraphQL\Mutations\Entity\UpdateEntityBase;
-use Youshido\GraphQL\Execution\ResolveInfo;
+use GraphQL\Type\Definition\ResolveInfo;
 
 /**
  * Simple mutation for updating an existing article node.

--- a/src/Plugin/GraphQL/Mutations/UpdateArticle.php
+++ b/src/Plugin/GraphQL/Mutations/UpdateArticle.php
@@ -2,7 +2,8 @@
 
 namespace Drupal\graphql_examples\Plugin\GraphQL\Mutations;
 
-use Drupal\graphql\GraphQL\Type\InputObjectType;
+use Drupal\graphql\Annotation\GraphQLMutation;
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
 use Drupal\graphql_core\Plugin\GraphQL\Mutations\Entity\UpdateEntityBase;
 use GraphQL\Type\Definition\ResolveInfo;
 
@@ -27,7 +28,12 @@ class UpdateArticle extends UpdateEntityBase {
   /**
    * {@inheritdoc}
    */
-  protected function extractEntityInput(array $args, ResolveInfo $info) {
+  protected function extractEntityInput(
+    $value,
+    array $args,
+    ResolveContext $context,
+    ResolveInfo $info
+  ) {
     return array_filter([
       'title' => $args['input']['title'],
       'body' => $args['input']['body'],


### PR DESCRIPTION
1. The namespace `Youshido\GraphQL\Execution\ResolveInfo` doesn't exist anymore.
2. the method extractEntityInput has more arguments in the lastest version